### PR TITLE
Fix deprecated use of Buffer

### DIFF
--- a/randombytes-native.android.js
+++ b/randombytes-native.android.js
@@ -1,7 +1,7 @@
 module.exports = function (length, cb) {
   var output = Array.create("byte", length);
   new java.security.SecureRandom().nextBytes(output);
-  var buf = new Buffer(android.util.Base64.encodeToString(output, android.util.Base64.DEFAULT), 'base64');
+  var buf = Buffer.from(android.util.Base64.encodeToString(output, android.util.Base64.DEFAULT), 'base64');
 
   if (cb) {
     cb (null, buf);

--- a/randombytes-native.ios.js
+++ b/randombytes-native.ios.js
@@ -1,7 +1,7 @@
 module.exports = function (length, cb) {
   var bytes = NSMutableData.dataWithLength(length);
   SecRandomCopyBytes(null, length, bytes.mutableBytes);
-  var buf = new Buffer(bytes.base64EncodedStringWithOptions(0), 'base64');
+  var buf = Buffer.from(bytes.base64EncodedStringWithOptions(0), 'base64');
 
   if (cb) {
     cb (null, buf);


### PR DESCRIPTION
Use of `new Buffer(string, encoding)` is depracated.
Replaced with `Buffer.from(string, encoding)`